### PR TITLE
Python linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             echo "MAIL_PORT=25" >> ./.env
             echo "MAIL_SENDER=change@me.com" >> ./.env
             echo "NODE_ENV=development" >> ./.env
-            echo "FLASK_API_URL=http://app:5434/graphql" >> ./.env
+            echo "REACT_FLASK_API_URL=http://api:5434/mobydq/api/v1/graphql" >> ./.env
 
       - run:
           name: Build Docker images
@@ -63,7 +63,7 @@ jobs:
           name: Run frontend tests
           when: always
           command: |
-            docker run --name mobydq-app-test -e JEST_JUNIT_OUTPUT="/reports/junit/js-test-results.xml" -e CI=true mobydq-app-test npm test -- --ci --reporters=jest-junit --updateSnapshot && exit 0
+            docker run --name mobydq-app-test -e JEST_JUNIT_OUTPUT="/reports/junit/js-test-results.xml" -e CI=true mobydq-app-test npm test -- --ci --reporters=jest-junit --updateSnapshot
 
       - run:
           name: Run frontend linter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,11 +53,17 @@ jobs:
             docker-compose -f ./test/docker-compose.yml up test
 
       - run:
+          name: Run backend linter
+          when: always
+          command: |
+            docker run --name mobydq-lint mobydq-test /bin/bash -c "find . -iname \"*.py\" | xargs pylint --output-format=pylint2junit.JunitReporter > lint-results.xml"
+
+      - run:
           name: Collect backend results
           when: always
           command: |
             docker cp mobydq-test:/srv/test-results.xml ./test-results/
-            # TODO collect linting
+            docker cp mobydq-lint:/srv/lint-results.xml ./test-results/
 
       - run:
           name: Run frontend tests

--- a/app/.eslintrc.json
+++ b/app/.eslintrc.json
@@ -1,3 +1,17 @@
 {
-    "extends": "airbnb"
+  "extends": [ "eslint:recommended", "plugin:react/recommended", "plugin:jest/recommended" ],
+  "plugins": [ "react", "jest" ],
+  "env": {
+    "browser": true,
+    "node": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module",
+     "ecmaFeatures": {
+      "jsx": true,
+      "modules": true,
+      "experimentalObjectRestSpread": true
+    }
+  }
 }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -4521,6 +4521,12 @@
         }
       }
     },
+    "eslint-plugin-jest": {
+      "version": "21.24.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-21.24.1.tgz",
+      "integrity": "sha512-+lJ6nvwJtDRQtTumCs/9gMuteiopArpHJbRbWqPaScCzlhTu1pEilWTUlTgDEtY7GOx7FdOMD3BO/mdxFb4yDg==",
+      "dev": true
+    },
     "eslint-plugin-jsx-a11y": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.1.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "eslint": "5.6.0",
     "eslint-config-airbnb": "^17.1.0",
+    "eslint-plugin-jest": "^21.24.1",
     "eslint-plugin-react": "^7.11.1",
     "jest-junit": "^5.2.0",
     "react-test-renderer": "^16.5.2"

--- a/app/run-container.sh
+++ b/app/run-container.sh
@@ -1,0 +1,2 @@
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml build app
+docker run -it --rm -v `pwd`/app/src:/usr/src/app/src -v `pwd`/app/public:/usr/src/app/public mobydq-app-dev "$@"

--- a/app/src/actions/sidebar.js
+++ b/app/src/actions/sidebar.js
@@ -3,4 +3,4 @@ export function isOpen(bool) {
     type: 'SIDEBAR_IS_OPEN',
     isOpen: bool
   };
-};
+}

--- a/app/src/reducers/sidebar.js
+++ b/app/src/reducers/sidebar.js
@@ -5,4 +5,4 @@ export function sidebarIsOpen(state=true, action) {
     default:
       return state;
   }
-};
+}

--- a/app/src/store/configureStore.js
+++ b/app/src/store/configureStore.js
@@ -7,4 +7,4 @@ export default function configureStore(initialState) {
     initialState,
     applyMiddleware(thunk)
   );
-};
+}

--- a/test/.pylintrc
+++ b/test/.pylintrc
@@ -1,0 +1,5 @@
+[TYPECHECK]
+ignored-modules = numpy
+
+[MESSAGES CONTROL]
+disable=line-too-long

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,13 +1,15 @@
 FROM mobydq-scripts:latest
 
 # Install Python dependencies
-RUN pip install nose2
+COPY ./requirements.txt ./
+
+RUN pip install -r requirements.txt
 
 # Set Python path to run tests with nose2
 ENV PYTHONPATH /srv/scripts:/srv/test:$PYTHONPATH
 
 # Create SQLite database
-RUN apt-get install sqlite3
+RUN apt-get install -y sqlite3
 
 # Test files
 WORKDIR /srv
@@ -19,3 +21,5 @@ COPY ./unittest.cfg .
 
 RUN chmod +x test/db-sqlite/database.sh \
     && test/db-sqlite/database.sh
+
+COPY .pylintrc ./

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,4 @@
+nose2==0.8.0
+pylint===2.1.1
+pylint2junit==1.0.0
+pyodbc==4.0.23


### PR DESCRIPTION
- Use recommended rules for frontend linting
- Use pylint to run python linting
- Create helper scripts to run frontend scripts locally

There are still many linting errors, but as the linter now runs they can be continously fixed